### PR TITLE
fix: make separate page for tickets

### DIFF
--- a/src/components/home/News.tsx
+++ b/src/components/home/News.tsx
@@ -15,7 +15,7 @@ export default function News({ timeLine }: Props) {
       <h2 className="sr-only">News</h2>
       {timeLine.map(
         ({ data, name }, i) =>
-          i < 6 &&
+          i < 9 &&
           (name === 'event' ? (
             <EventCard key={data.id} event={data} />
           ) : name === 'matchreport' ? (

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -76,7 +76,7 @@ export const headerLinks = [
   },
   {
     name: 'Tickets',
-    href: '/#tickets-abbonementen',
+    href: '/tickets',
     blank: false,
   },
   {

--- a/src/pages/tickets/index.tsx
+++ b/src/pages/tickets/index.tsx
@@ -1,0 +1,17 @@
+import Head from "next/head";
+import TicketsAndAbos from "@/components/home/TicketsAndAbos";
+import React from "react";
+
+export default function Home() {
+    return (
+        <>
+            <Head>
+                <title>Sasja HC | Tickets</title>
+            </Head>
+            <main>
+                <h1 className="sr-only">Sasja HC | Home</h1>
+                <TicketsAndAbos />
+            </main>
+        </>
+    )
+}

--- a/src/services/firebase/firestore.ts
+++ b/src/services/firebase/firestore.ts
@@ -49,16 +49,18 @@ export const docRefToModel = async <M>(docRef: DocumentReference<DocumentData>) 
 
 export const createTimeLine = (
   events: EventModel[],
-  news: NewsModel[],
+  pinnedNews: NewsModel[],
+  currentNews: NewsModel[],
   matchReports: MatchReportModel[]
 ) => {
-  const timeLine: TimeLine = []
+  const staticTimeLine: TimeLine = []
+  events.forEach((event) => staticTimeLine.push({ name: 'event', data: event }))
+  pinnedNews.forEach((news) => staticTimeLine.push({ name: 'news', data: news }))
+  const dynamicTimeLine: TimeLine = []
 
-  events.forEach((event) => timeLine.push({ name: 'event', data: event }))
-  news.forEach((news) => timeLine.push({ name: 'news', data: news }))
-  matchReports.forEach((matchReport) => timeLine.push({ name: 'matchreport', data: matchReport }))
+  currentNews.forEach((news) => dynamicTimeLine.push({ name: 'news', data: news }))
+  matchReports.forEach((matchReport) => dynamicTimeLine.push({ name: 'matchreport', data: matchReport }))
+  dynamicTimeLine.sort((t1, t2) => new Date(t2.data.time).getTime() - new Date(t1.data.time).getTime())
 
-  timeLine.sort((t1, t2) => new Date(t2.data.time).getTime() - new Date(t1.data.time).getTime())
-
-  return timeLine
+  return [...staticTimeLine, ...dynamicTimeLine, ]
 }


### PR DESCRIPTION
fix: allow up to 9 cards on the frontpage
fix: events first, then pinned news, then current match reports and news